### PR TITLE
update website

### DIFF
--- a/backend/src/throws/infractions.rs
+++ b/backend/src/throws/infractions.rs
@@ -7,10 +7,3 @@ pub enum InfractionType {
     RightSector,
     Circle,
 }
-
-#[derive(Debug, Clone, Serialize)]
-pub struct Infraction {
-    #[serde(rename = "type")]
-    pub infraction_type: InfractionType,
-    pub confidence: f32,
-}

--- a/backend/src/throws/mod.rs
+++ b/backend/src/throws/mod.rs
@@ -3,7 +3,6 @@ pub mod simulate_throw;
 pub mod throw_analysis;
 pub mod throw_type;
 
-pub use infractions::Infraction;
 pub use infractions::InfractionType;
 pub use throw_analysis::ThrowAnalysisResponse;
 pub use throw_type::GetThrowTypeResponse;

--- a/backend/src/throws/simulate_throw.rs
+++ b/backend/src/throws/simulate_throw.rs
@@ -1,17 +1,17 @@
-use super::{Infraction, InfractionType, ThrowAnalysisResponse, ThrowType};
+use super::{InfractionType, ThrowAnalysisResponse, ThrowType};
 use chrono::Utc;
 use std::f32::consts::PI;
 use uuid::Uuid;
 
 /// Based on what sport is being evaluated, return the field dimensions.
-/// 
+///
 /// The first number is the diameter of the throwing circle in meters, or
 /// for javelin it's the length of the runway.
-/// 
+///
 /// The second number is the length of the field in meters.
-/// 
+///
 /// The third number is the sector angle, in degrees.
-/// 
+///
 /// For reference, see the following link:
 /// https://www.cits.wa.gov.au/sport-and-recreation/sports-dimensions-guide/athletics-throwing-events
 pub fn get_field_dimensions(throw_type: ThrowType) -> (f32, f32, f32) {
@@ -23,39 +23,28 @@ pub fn get_field_dimensions(throw_type: ThrowType) -> (f32, f32, f32) {
     }
 }
 
-pub fn get_random_infractions() -> Vec<Infraction> {
+pub fn get_random_infractions() -> Vec<InfractionType> {
     let infraction_probability = 0.3;
 
-    let mut infractions: Vec<Infraction> = vec![];
+    let mut infractions: Vec<InfractionType> = vec![];
 
     if rand::random::<f32>() < infraction_probability {
-        infractions.push(Infraction {
-            infraction_type: InfractionType::LeftSector,
-            confidence: rand::random::<f32>(),
-        });
+        infractions.push(InfractionType::LeftSector);
     } else if rand::random::<f32>() < infraction_probability {
-        infractions.push(Infraction {
-            infraction_type: InfractionType::RightSector,
-            confidence: rand::random::<f32>(),
-        });
+        infractions.push(InfractionType::RightSector);
     }
 
     if rand::random::<f32>() < infraction_probability {
-        infractions.push(Infraction {
-            infraction_type: InfractionType::Circle,
-            confidence: rand::random::<f32>(),
-        });
+        infractions.push(InfractionType::Circle);
     }
 
     infractions
 }
 
 pub fn simulate_throw_event(throw_type: ThrowType) -> ThrowAnalysisResponse {
-    let (circle_diameter, field_length, sector_angle): (f32, f32, f32) = get_field_dimensions(throw_type);
+    let (circle_diameter, field_length, sector_angle): (f32, f32, f32) =
+        get_field_dimensions(throw_type);
 
-    // Note: Does the math look okay? Sometimes when I'm running sims, the object
-    // will appear to land in the throwing area or out of bounds and not be an
-    // infraction.
     let rand_distance_base: f32 = rand::random::<f32>() * field_length;
     let rand_distance: f32 = circle_diameter / 2.0 + rand_distance_base;
 
@@ -71,7 +60,7 @@ pub fn simulate_throw_event(throw_type: ThrowType) -> ThrowAnalysisResponse {
     let random_y = rand_distance * ((rand_pos_theta * PI) / 180.0).sin() * random_y_multiplier;
 
     // Cumulative probability of 26.5% chance of infraction.
-    let infractions: Vec<Infraction> = if rand::random::<f32>() < 0.4 {
+    let infractions: Vec<InfractionType> = if rand::random::<f32>() < 0.4 {
         get_random_infractions()
     } else {
         Vec::new()
@@ -80,7 +69,10 @@ pub fn simulate_throw_event(throw_type: ThrowType) -> ThrowAnalysisResponse {
     // Show landing point as long as there is no sector violation. It is still
     // useful to show the landing point even if there is a circle infraction.
     let has_sector_violation = infractions.iter().any(|infraction| {
-        matches!(infraction.infraction_type, InfractionType::LeftSector | InfractionType::RightSector)
+        matches!(
+            infraction,
+            InfractionType::LeftSector | InfractionType::RightSector
+        )
     });
     let landing_point_x_y: Option<(f32, f32)> = if !has_sector_violation {
         Some((random_x, random_y))
@@ -95,7 +87,6 @@ pub fn simulate_throw_event(throw_type: ThrowType) -> ThrowAnalysisResponse {
         distance_m: rand_distance,
         infractions,
         images: vec![
-            "https://placeholdpicsum.dev/photo/id/729/400".to_string(),
             "https://placeholdpicsum.dev/photo/id/929/600/400".to_string(),
             "https://placeholdpicsum.dev/photo/id/925/600/400".to_string(),
         ],

--- a/backend/src/throws/throw_analysis.rs
+++ b/backend/src/throws/throw_analysis.rs
@@ -1,4 +1,4 @@
-use super::{Infraction, ThrowType};
+use super::{InfractionType, ThrowType};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -16,13 +16,13 @@ pub struct ThrowAnalysisResponse {
     // Whether the throw is shot put, discus, hammer, or javelin.
     pub throw_type: ThrowType,
 
-    // The distance from where the implement landed to the inside edge of 
+    // The distance from where the implement landed to the inside edge of
     // the stop board, in meters.
     pub distance_m: f32,
 
     // Can possibly have circle infractions, sector violations, both,
     // or no infractions.
-    pub infractions: Vec<Infraction>,
+    pub infractions: Vec<InfractionType>,
 
     // The URLs associated with the images of the object's landing point.
     pub images: Vec<String>,

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -43,10 +43,8 @@ export default function Page() {
             onChange={async (e) => {
               setCurrentThrow(null);
               setStatus("waiting");
-              const newType = e.target.value as ThrowType;
-              setSelectedThrowType(newType);
-
               try {
+                const newType = e.target.value as ThrowType;
                 const res = await fetch(urlPostThrowType, {
                   method: "POST",
                   headers: { "Content-Type": "application/json" },
@@ -57,10 +55,10 @@ export default function Page() {
                   const message = errorData.message || res.statusText || 'Unknown Error';
                   throw new Error(`HTTP ${res.status}: ${message}`);
                 }
+                setSelectedThrowType(newType);
               } catch (err) {
                 console.error("POST /throw-type failed. Did you forget to start the Axum server if you are running in integration mode?", err);
               }
-
             }}
             className="bg-gray-800 border border-gray-600 text-white rounded px-3 py-2 text-base font-normal focus:outline-none focus:ring-2 focus:ring-blue-500"
           >

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -22,7 +22,7 @@ export default function Page() {
   const [error, setError] = useState<string | null>(null);
   const [selectedThrowType, setSelectedThrowType] = useState<ThrowType>(ThrowType.SHOTPUT);
   const [isLoadingCurrentThrow, setIsLoadingCurrentThrow] = useState(false);
-  
+
   // URL varies based on whether or not the request is same origin (frontend-only
   // dev, production, etc.) or if request is across servers (integration-dev).
   const urlPostThrowType = process.env.NEXT_PUBLIC_API_BASE_URL + "/api/throw-type";
@@ -50,12 +50,17 @@ export default function Page() {
                 const res = await fetch(urlPostThrowType, {
                   method: "POST",
                   headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({ throwType: newType }),
+                  body: JSON.stringify({ throwType: newType.toLocaleLowerCase() }),
                 });
+                if (!res.ok) {
+                  const errorData = await res.json().catch(() => ({}));
+                  const message = errorData.message || res.statusText || 'Unknown Error';
+                  throw new Error(`HTTP ${res.status}: ${message}`);
+                }
               } catch (err) {
                 console.error("POST /throw-type failed. Did you forget to start the Axum server if you are running in integration mode?", err);
               }
-              
+
             }}
             className="bg-gray-800 border border-gray-600 text-white rounded px-3 py-2 text-base font-normal focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
@@ -118,7 +123,7 @@ export default function Page() {
           <ul className="list-disc ml-5">
             {currentThrow!.infractions.map((i, idx) => (
               <li key={idx}>
-                {currentThrow?.throwType === ThrowType.JAVELIN ? 'Foul Throw' : displayNameForInfraction(i.type)} (confidence: {(i.confidence * 100).toFixed(0)}%)
+                {currentThrow?.throwType === ThrowType.JAVELIN ? 'Foul Throw' : displayNameForInfraction(i)}
               </li>
             ))}
           </ul>
@@ -131,17 +136,17 @@ export default function Page() {
         <div className="col-span-9 flex justify-center">
           {currentThrow ? (
             selectedThrowType === ThrowType.JAVELIN ? (
-                <JavelinField
-                  landingPoint={currentThrow.landingPointXY}
-                  infractions={currentThrow.infractions.map((i) => i.type)}
-                />
-              ) : (
-                <CircleField
-                  throwType={selectedThrowType}
-                  landingPoint={currentThrow.landingPointXY}
-                  infractions={currentThrow.infractions.map((i) => i.type)}
-                />
-              )
+              <JavelinField
+                landingPoint={currentThrow.landingPointXY}
+                infractions={currentThrow.infractions}
+              />
+            ) : (
+              <CircleField
+                throwType={selectedThrowType}
+                landingPoint={currentThrow.landingPointXY}
+                infractions={currentThrow.infractions}
+              />
+            )
           ) : (
             <p className="text-gray-400">Waiting for throw...</p>
           )}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -6,22 +6,16 @@ import {
 } from "./schemas";
 import { v4 as uuidv4 } from "uuid";
 
-function randomInfractions(): { type: Infraction; confidence: number }[] {
-  const infractions: { type: Infraction; confidence: number }[] = [];
+function randomInfractions(): Infraction[] {
+  const infractions: Infraction[] = [];
   if (Math.random() < 0.3) {
-    infractions.push({
-      type: Infraction.LEFT_SECTOR,
-      confidence: Math.random(),
-    });
+    infractions.push(Infraction.LEFT_SECTOR);
   }
   if (Math.random() < 0.3) {
-    infractions.push({
-      type: Infraction.RIGHT_SECTOR,
-      confidence: Math.random(),
-    });
+    infractions.push(Infraction.RIGHT_SECTOR);
   }
   if (Math.random() < 0.3) {
-    infractions.push({ type: Infraction.CIRCLE, confidence: Math.random() });
+    infractions.push(Infraction.CIRCLE);
   }
   return infractions;
 }
@@ -73,7 +67,6 @@ export async function getThrowEvent(throwType: ThrowType): Promise<ThrowEvent> {
     distanceM: randDistance,
     infractions,
     images: [
-      "https://placeholdpicsum.dev/photo/800/450",
       "https://placeholdpicsum.dev/photo/1600/900",
       "https://placeholdpicsum.dev/photo/1200/675",
     ].sort(() => Math.random() - 0.5),

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -49,22 +49,17 @@ export function circleFieldDimsForThrowType(throwType: ThrowType) {
   }
 }
 
-export const infractionSchema = z
-  .object({
-    type: z.enum(Infraction),
-    confidence: z.number().min(0).max(1),
-  })
-  .strict();
-
 export const throwEventSchema = z
   .object({
     throwId: z.uuid(),
-    frameTimestampFromCameraMicroseconds: z.string().refine((val) => !isNaN(Date.parse(val)), {
-      message: "Invalid timestamp",
-    }),
+    frameTimestampFromCameraMicroseconds: z
+      .string()
+      .refine((val) => !isNaN(Date.parse(val)), {
+        message: "Invalid timestamp",
+      }),
     throwType: z.enum(ThrowType),
     distanceM: z.number().nonnegative(),
-    infractions: z.array(infractionSchema),
+    infractions: z.array(z.enum(Infraction)),
     images: z.array(z.url()),
     landingPointXY: z.tuple([z.number(), z.number()]).optional(),
   })


### PR DESCRIPTION
Closes #33 

Note that the confusion about the math was not actually a math bug. The frontend was sending invalid requests when trying to change the throw type, so regardless of what throw type was selected, the fake throw data was always for a shot put field.

This was fixed by
- making the frontend lowercase the throw type in its POST requests to /api/throw-type , so it sends valid requests
- Adding better error logging on the frontend
- Not letting the frontend update its throw type state unless that POST request succeeds