### PR TITLE
Implement githooks to make submodules cleaner

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+ 
+# Remove submodule directories that aren't in .gitmodules anymore
+git submodule sync
+git submodule update --init --recursive --depth 1
+ 
+# Get rid of untracked orphaned submodule directories. This only occurs if
+# switching from a branch with submodules to a branch that doesn't
+# have them yet.
+git clean -ffd third_party/

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -112,6 +112,5 @@ bazel run @rules_rust//tools/rust_analyzer:gen_rust_project
 
 echo "Setting up git hooks..."
 git config core.hooksPath .githooks
-chmod +x .githooks/post-checkout
 
 echo "Setup complete."

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -110,4 +110,8 @@ echo "Generating Rust project..."
 cd "$PROJECT_ROOT"
 bazel run @rules_rust//tools/rust_analyzer:gen_rust_project
 
+echo "Setting up git hooks..."
+git config core.hooksPath .githooks
+chmod +x .githooks/post-checkout
+
 echo "Setup complete."

--- a/scripts/setup_mac.sh
+++ b/scripts/setup_mac.sh
@@ -105,7 +105,5 @@ bazel run @rules_rust//tools/rust_analyzer:gen_rust_project
 
 echo "Setting up git hooks..."
 git config core.hooksPath .githooks
-chmod +x .githooks/post-checkout
-
 
 echo "Setup complete."

--- a/scripts/setup_mac.sh
+++ b/scripts/setup_mac.sh
@@ -103,5 +103,9 @@ echo "Generating Rust project..."
 cd "$PROJECT_ROOT"
 bazel run @rules_rust//tools/rust_analyzer:gen_rust_project
 
+echo "Setting up git hooks..."
+git config core.hooksPath .githooks
+chmod +x .githooks/post-checkout
+
 
 echo "Setup complete."


### PR DESCRIPTION
Because sometimes one branch (i.e. main) had more submodules than feature branches, switching between them would cause trying to delete the submodule directories, but since they weren't empty, deletion would fail, leading to build issues.

Example:
```
➜  mjolnir git:(main) git checkout implement-downsampling-rust 
warning: unable to rmdir 'third_party/aravis': Directory not empty
warning: unable to rmdir 'third_party/aravis-rs': Directory not empty
warning: unable to rmdir 'third_party/glib': Directory not empty
warning: unable to rmdir 'third_party/gtk-rs-core': Directory not empty
warning: unable to rmdir 'third_party/libffi': Directory not empty
warning: unable to rmdir 'third_party/pcre2': Directory not empty
warning: unable to rmdir 'third_party/zlib': Directory not empty
Switched to branch 'implement-downsampling-rust'
Your branch is up to date with 'origin/implement-downsampling-rust'.

➜  mjolnir git:(implement-downsampling-rust) ✗ bazel build //...
WARNING: Target pattern parsing failed.
ERROR: Skipping '//...': error loading package under directory '': error loading package 'third_party/zlib': Unable to find package for @@[unknown repo 'rules_license' requested from @@]//rules:license.bzl: The repository '@@[unknown repo 'rules_license' requested from @@]' could not be resolved: No repository visible as '@rules_license' from main repository.
ERROR: error loading package under directory '': error loading package 'third_party/zlib': Unable to find package for @@[unknown repo 'rules_license' requested from @@]//rules:license.bzl: The repository '@@[unknown repo 'rules_license' requested from @@]' could not be resolved: No repository visible as '@rules_license' from main repository.
INFO: Elapsed time: 0.287s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
➜  mjolnir git:(implement-downsampling-rust) ✗
```

I added a githook to automatically do the following when changing branches:
1. sync submodule URLs
2. update submodules
3. delete untracked directories in third_party

I also added lines in setup scripts to configure this githook